### PR TITLE
Corrigindo Prettier "Delete `CR`" no Windows.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -10,7 +10,12 @@
     "jsx-quotes": ["error", "prefer-single"],
     "react/jsx-boolean-value": [0],
     "react-hooks/rules-of-hooks": "error",
-    "prettier/prettier": 2,
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ],
     "space-before-function-paren": 0
   }
 }


### PR DESCRIPTION
## Alteração proposta
Quando o desenvolvedor pressiona a tecla "Enter" no macOS ou no Linux o Visual Studio Code entende como "\r" (caractere de escape CR), já quando estamos em Windows é o "\n" (caractere de quebra de linha), se eu ir ao Visual Studio Code e em seu menu inferior, no lado direito trocar de "CRLF" para "LF" os erros de quebra de linha desaparacem, pois o VSCode começa interpretar aquilo como um "\n" e não "\r", e então a pequena alteração no arquivo `.eslintrc.json` corrige este problema.

## Este PR fecha a seguunte issue:
#34 