### PR TITLE
feat(pandora-frontend): add oauth0 option from pandora-frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "dependencies": {
     "@naveteam/dispatcher": "^1.1.0",
-    "@naveteam/pandora-frontend": "^1.0.1",
+    "@naveteam/pandora-frontend": "^1.0.2",
     "@sentry/browser": "5.14",
     "@styled-system/prop-types": "^5.1.5",
     "@welldone-software/why-did-you-render": "^6.0.0-rc.1",

--- a/src/context/user-context.js
+++ b/src/context/user-context.js
@@ -2,7 +2,7 @@ import React, { createContext, useContext, useEffect } from 'react'
 import { useQuery, useMutation, useQueryCache } from 'react-query'
 
 import { getUser, login as loginService } from 'services/auth'
-import { setAccessToken, setRefreshToken, clearToken, getToken } from 'helpers'
+import { setAccessToken, setRefreshToken, clearToken, getToken, setToken } from 'helpers'
 
 const UserContext = createContext()
 
@@ -25,6 +25,8 @@ const UserProvider = props => {
     onSuccess: ({ access_token, refresh_token }) => {
       setAccessToken(access_token)
       setRefreshToken(refresh_token)
+      // trocar access_token e refresh_token por token caso a autenticação seja feita com OAuth0
+      // setToken(token)
       queryCache.invalidateQueries('user', { refetchInactive: true })
     }
   })

--- a/src/helpers/auth.js
+++ b/src/helpers/auth.js
@@ -1,12 +1,18 @@
-import { ACCESS_TOKEN, REFRESH_TOKEN } from 'helpers'
+import { ACCESS_TOKEN, REFRESH_TOKEN, TOKEN } from 'helpers'
 
 export const getToken = () => localStorage.getItem(ACCESS_TOKEN)
+
+// trocar função de "getToken()" caso a autenticação seja feita com OAuth0
+// export const getToken = () => localStorage.getItem(TOKEN)
 
 export const clearToken = () => {
   localStorage.removeItem(ACCESS_TOKEN)
   localStorage.removeItem(REFRESH_TOKEN)
+  localStorage.removeItem(TOKEN)
 }
 
 export const setAccessToken = token => localStorage.setItem(ACCESS_TOKEN, token)
 
 export const setRefreshToken = token => localStorage.setItem(REFRESH_TOKEN, token)
+
+export const setToken = token => localStorage.setItem(TOKEN, token)

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -4,3 +4,5 @@ export const MEDIATABLET = 768
 export const ACCESS_TOKEN = '@react-boilerplate-access-token'
 
 export const REFRESH_TOKEN = '@react-boilerplate-refresh-token'
+
+export const TOKEN = '@react-boilerplate-token'

--- a/src/providers/fetchClient.js
+++ b/src/providers/fetchClient.js
@@ -1,6 +1,6 @@
-import { OAuth2 } from '@naveteam/pandora-frontend'
+import { OAuth2, OAuth0 } from '@naveteam/pandora-frontend'
 
-import { ACCESS_TOKEN, REFRESH_TOKEN } from 'helpers'
+import { ACCESS_TOKEN, REFRESH_TOKEN, TOKEN } from 'helpers'
 
 const options = {
   api_url: process.env.REACT_APP_API_URL,
@@ -10,5 +10,16 @@ const options = {
 }
 
 const instance = OAuth2.createInstance(options)
+
+/*
+trocar para a instancia abaixo caso a autenticação seja feita com OAuth0
+
+const options = {
+  api_url: process.env.REACT_APP_API_URL,
+  token_name: TOKEN
+}
+
+const instance = OAuth0.createInstance(options)
+*/
 
 export default instance


### PR DESCRIPTION
<!-- 🚨 Please review the how to contribute for contributing to this repository. -->

## Proposed changes

<!-- Describe the big picture of your changes here to communicate to the maintainers why we should accept this pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. -->

O pacote de autenticação, `pandora-frontend`, agora tem a possibilidade de utilizar OAuth0 além da OAuth2. Foi adicionado o código necessário para fazer a utilização do OAuth0, mas está comentado, dando a opção de escolher qual dos métodos vai ser utilizado ao iniciar um projeto.

## Does this close any currently open issues?

<!-- Put here the refence to the issue or PR -->

## Checklist

Put an x in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code.

<!-- - [ ] I have read the CONTRIBUTING doc -->

- [x] I have read the CONTRIBUTING guide and follow all rules
- [x] [Squash pull request into a single commit](http://eli.thegreenplace.net/2014/02/19/squashing-github-pull-requests-into-a-single-commit/)
  <!-- - [ ] I have added tests that prove my fix is effective or that my feature works -->
- [x] I have added necessary documentation (if appropriate)
