### PR TITLE
fix: pre commit linter

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,6 @@
   ],
   "lint-staged": {
     "*.{js, jsx}": [
-      "eslint --fix --ignore-path .gitignore .",
       "prettier --write"
     ]
   },


### PR DESCRIPTION
o lint-staged também estava chamando o eslint, fazendo o eslint percorrer todos os arquivos do projeto e não apenas os que estão em stage. Isso tornava o lint-staged "inútil". 